### PR TITLE
do not throw exception when github status api fail

### DIFF
--- a/src/main/java/com/naver/nid/cover/CoverChecker.java
+++ b/src/main/java/com/naver/nid/cover/CoverChecker.java
@@ -70,7 +70,6 @@ public final class CoverChecker {
 			reporter.report(check);
 			log.info("check result {}", check.result());
 		} catch (Exception e) {
-			log.error("check result fail", e);
 			NewCoverageCheckReport failResult = NewCoverageCheckReport.builder()
 					.error(e)
 					.build();

--- a/src/main/java/com/naver/nid/cover/github/GithubStatusManager.java
+++ b/src/main/java/com/naver/nid/cover/github/GithubStatusManager.java
@@ -16,12 +16,15 @@
 package com.naver.nid.cover.github;
 
 import com.naver.nid.cover.github.model.CommitStatusCreate;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.egit.github.core.CommitStatus;
 import org.eclipse.egit.github.core.RepositoryId;
 import org.eclipse.egit.github.core.client.GitHubClient;
+import org.slf4j.Logger;
 
 import java.io.IOException;
 
+@Slf4j
 public class GithubStatusManager {
 
 	private GitHubClient client;
@@ -34,8 +37,12 @@ public class GithubStatusManager {
 		this.sha = sha;
 	}
 
-	public void setStatus(CommitStatusCreate status) throws IOException {
+	public void setStatus(CommitStatusCreate status) {
 		String url = String.format("/repos/%s/statuses/%s", repoId.generateId(), sha);
-		client.post(url, status, CommitStatus.class);
+		try {
+			client.post(url, status, CommitStatus.class);
+		} catch (Exception e) {
+			log.warn("error while set status({}) {}", url, e);
+		}
 	}
 }

--- a/src/main/resources/templates/error.md
+++ b/src/main/resources/templates/error.md
@@ -2,4 +2,6 @@
 
 coverage check fail. please retry. [(${icon})]
 
+[Please let me know](https://github.com/naver/cover-checker/issues/new) when error again.
+
 [(${error})]

--- a/src/test/java/com/naver/nid/cover/reporter/github/GithubPullRequestReporterTest.java
+++ b/src/test/java/com/naver/nid/cover/reporter/github/GithubPullRequestReporterTest.java
@@ -60,6 +60,8 @@ class GithubPullRequestReporterTest {
 			"\n" +
 			"coverage check fail. please retry. :fearful:\n" +
 			"\n" +
+			"[Please let me know](https://github.com/naver/cover-checker/issues/new) when error again.\n" +
+			"\n" +
 			"test error";
 
 	private GithubPullRequestManager mockPrManager;


### PR DESCRIPTION
- suppress exception in status manager
- fix error comment
- fix test code result
---
- 여러가지 이유로 status api에서 실패할 경우 전체 처리 결과가 실패 처리되는데 이를 방지합니다.
- 에러 발생했을 때 바로 report 할 수 있도록 메시지 수정했습니다.