### PR TITLE
Bug fix

### DIFF
--- a/src/test/java/com/naver/nid/cover/parser/diff/DiffMapperTest.java
+++ b/src/test/java/com/naver/nid/cover/parser/diff/DiffMapperTest.java
@@ -1,0 +1,49 @@
+package com.naver.nid.cover.parser.diff;
+
+import com.naver.nid.cover.parser.diff.model.*;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DiffMapperTest {
+
+	private DiffMapper mapper = new DiffMapper();
+
+	@Test
+	public void testSingleLineFix() {
+		String testContent = "@@ -1 +1 @@\n-test\n\\\\ No newline at end of file\n+test1\n\\\\ No newline at end of file";
+
+		Diff test = mapper.apply(RawDiff.builder().fileName("test")
+				.rawDiff(Arrays.asList(testContent.split("\n"))).build());
+
+		assertEquals(1, test.getDiffSectionList().size());
+
+		DiffSection diffSection = test.getDiffSectionList().get(0);
+		List<Line> lineList = diffSection.getLineList();
+		assertEquals(2, lineList.size());
+		assertEquals("test", lineList.get(0).getBody());
+		assertEquals(ModifyType.DEL, lineList.get(0).getType());
+		assertEquals("test1", lineList.get(1).getBody());
+		assertEquals(ModifyType.ADD, lineList.get(1).getType());
+	}
+
+
+	@Test
+	public void testNewSingleLine() {
+		String testContent = "@@ -0 +1 @@\n+test1\n\\\\ No newline at end of file";
+
+		Diff test = mapper.apply(RawDiff.builder().fileName("test")
+				.rawDiff(Arrays.asList(testContent.split("\n"))).build());
+
+		assertEquals(1, test.getDiffSectionList().size());
+
+		DiffSection diffSection = test.getDiffSectionList().get(0);
+		List<Line> lineList = diffSection.getLineList();
+		assertEquals(1, lineList.size());
+		assertEquals("test1", lineList.get(0).getBody());
+		assertEquals(ModifyType.ADD, lineList.get(0).getType());
+	}
+}


### PR DESCRIPTION
CoverChecker break when diff list has file that single line. (e.g. minified css)

CoverChecker available only multi-line diff header.(`@@ -x,y +m,n @@`)
So, occur error when single line diff header. (`@@ -1 +1 @@`)

This pull request make CoverCheck can take single line diff header.

- add Diff head line matcher for single line diff pattern
- add test code

---

diff 헤더에 여러줄이 수정되는 경우만 고려하여 패턴 매칭을 하여 한 줄로만 구성되어 있는 css 파일을 체크할 때는 에러가 발생하고 있었습니다.

이 pr 는 한 줄로 구성된 파일의 diff도 파싱할 수 있도록 합니다.