### PR TITLE
limited to commit status description

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.naver.nid</groupId>
     <artifactId>coverchecker</artifactId>
-    <version>1.3.1</version>
+    <version>1.3.2</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/com/naver/nid/cover/github/model/CommitStatusCreate.java
+++ b/src/main/java/com/naver/nid/cover/github/model/CommitStatusCreate.java
@@ -26,6 +26,14 @@ public class CommitStatusCreate {
 	private String description;
 	private String context;
 
+	public String getDescription() {
+		if (description.length() > 135) {
+			return description.substring(0, 132) + "...";
+		} else {
+			return description;
+		}
+	}
+
 	public enum State {
 		success, failure, pending, error
 	}


### PR DESCRIPTION
Reduce commit status description for no occured error when description over 140 characters.
Show only 132 characters and an ellipsis when description has over 135 characters.

---

커밋 상태 표시에서 description 의 길이가 140 자가 넘어갈 때 에러가 발생합니다.
이를 방지하기 위해 132자까지만 보이고 ... 로 줄이도록 변경합니다.