### PR TITLE
#30 file path normalize

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -4,7 +4,7 @@ name: cover-checker test and get coverage
 on:
   pull_request:
     branches: [ master ]
-    types: [opened, synchronize, reopened, edited, ready_for_review, review_requested]
+    types: [opened, synchronize, reopened, edited, ready_for_review]
 
 jobs:
   test-linux:
@@ -21,7 +21,7 @@ jobs:
       shell: bash
       env:
         ACCESS_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: java -jar ./cover-checker-console/target/cover-checker-console-1.4.1-jar-with-dependencies.jar -c ./cover-checker-cobertura/target/site/jacoco -c ./cover-checker-console/target/site/jacoco -c ./cover-checker-core/target/site/jacoco/ -c ./cover-checker-github/target/site/jacoco -c ./cover-checker-jacoco/target/site/jacoco -t 80 -r $GITHUB_REPOSITORY -g $ACCESS_TOKEN -p $(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
+      run: java -jar ./cover-checker-console/target/cover-checker-console-1.4.2-jar-with-dependencies.jar -c ./cover-checker-cobertura/target/site/jacoco -c ./cover-checker-console/target/site/jacoco -c ./cover-checker-core/target/site/jacoco/ -c ./cover-checker-github/target/site/jacoco -c ./cover-checker-jacoco/target/site/jacoco -t 80 -r $GITHUB_REPOSITORY -g $ACCESS_TOKEN -p $(echo $GITHUB_REF | awk 'BEGIN { FS = "/" } ; { print $3 }')
   test-macos:
     runs-on: macos-latest
     steps:

--- a/cover-checker-cobertura/pom.xml
+++ b/cover-checker-cobertura/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>coverchecker</artifactId>
         <groupId>com.naver.nid</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cover-checker-cobertura/src/main/java/com/naver/nid/cover/cobertura/CoberturaCoverageReportHandler.java
+++ b/cover-checker-cobertura/src/main/java/com/naver/nid/cover/cobertura/CoberturaCoverageReportHandler.java
@@ -19,6 +19,7 @@ import com.naver.nid.cover.parser.coverage.CoverageReportXmlHandler;
 import com.naver.nid.cover.parser.coverage.model.CoverageStatus;
 import com.naver.nid.cover.parser.coverage.model.FileCoverageReport;
 import com.naver.nid.cover.parser.coverage.model.LineCoverageReport;
+import com.naver.nid.cover.util.PathUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.xml.sax.Attributes;
 
@@ -110,7 +111,7 @@ public class CoberturaCoverageReportHandler extends CoverageReportXmlHandler {
 	 * @param attributes xml attribute
 	 */
 	private void initClass(Attributes attributes) {
-		Path filePath = Paths.get(attributes.getValue(ATTR_FILENAME));
+		Path filePath = Paths.get(PathUtils.generalizeSeparator(attributes.getValue(ATTR_FILENAME)));
 		if(log.isDebugEnabled()) {
 			log.debug("parse class {}({})", attributes.getValue("name"), filePath);
 		}

--- a/cover-checker-cobertura/src/main/java/com/naver/nid/cover/cobertura/CoberturaCoverageReportHandler.java
+++ b/cover-checker-cobertura/src/main/java/com/naver/nid/cover/cobertura/CoberturaCoverageReportHandler.java
@@ -23,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.xml.sax.Attributes;
 
 import java.math.BigInteger;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -46,7 +48,8 @@ public class CoberturaCoverageReportHandler extends CoverageReportXmlHandler {
 
 	private boolean isNowMethod; // 현재 메소드 내부인지
 
-	private Map<String, FileCoverageReport> reports = new HashMap<>();
+	private final Map<Path, FileCoverageReport> reports = new HashMap<>();
+
 	private List<LineCoverageReport> lineReports;
 	private FileCoverageReport current;
 
@@ -107,18 +110,18 @@ public class CoberturaCoverageReportHandler extends CoverageReportXmlHandler {
 	 * @param attributes xml attribute
 	 */
 	private void initClass(Attributes attributes) {
-		String fileName = attributes.getValue(ATTR_FILENAME);
+		Path filePath = Paths.get(attributes.getValue(ATTR_FILENAME));
 		if(log.isDebugEnabled()) {
-			log.debug("parse class {}({})", attributes.getValue("name"), fileName);
+			log.debug("parse class {}({})", attributes.getValue("name"), filePath);
 		}
-		if (reports.containsKey(fileName)) {
-			current = reports.get(fileName);
+		if (reports.containsKey(filePath)) {
+			current = reports.get(filePath);
 			lineReports = current.getLineCoverageReportList();
 		} else {
 			current = new FileCoverageReport();
 			lineReports = new ArrayList<>();
-
-			current.setFileName(fileName);
+			String fileName = filePath.getFileName().toString();
+			current.setFileName(filePath);
 			current.setType(fileName.substring(fileName.lastIndexOf('.') + 1));
 			current.setLineCoverageReportList(lineReports);
 		}

--- a/cover-checker-cobertura/src/test/java/com/naver/nid/cover/cobertura/CoberturaXmlReportParserTest.java
+++ b/cover-checker-cobertura/src/test/java/com/naver/nid/cover/cobertura/CoberturaXmlReportParserTest.java
@@ -20,7 +20,7 @@ class CoberturaXmlReportParserTest {
 		List<FileCoverageReport> parsed = parser.parse(getClass().getClassLoader().getResource("reports/coverage.xml"));
 		assertEquals(1, parsed.size());
 		assertSame(CoverageStatus.COVERED, parsed.stream()
-				.filter(r -> r.getFileName().contains("CoberturaReportHandler"))
+				.filter(r -> r.getFileName().endsWith("CoberturaReportHandler.java"))
 				.findFirst().flatMap(r -> r.getLineCoverageReportList().stream()
 						.filter(lr -> lr.getLineNum() == 68).findFirst()).orElseThrow(AssertionError::new).getStatus());
 

--- a/cover-checker-console/pom.xml
+++ b/cover-checker-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>coverchecker</artifactId>
         <groupId>com.naver.nid</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -81,7 +81,7 @@
                             </addDefaultImplementationEntries>
                         </manifest>
                     </archive>
-                    <finalName>${artifactId}</finalName>
+                    <finalName>${project.artifactId}</finalName>
                 </configuration>
             </plugin>
         </plugins>

--- a/cover-checker-core/pom.xml
+++ b/cover-checker-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>coverchecker</artifactId>
         <groupId>com.naver.nid</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/checker/NewCoverageChecker.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/checker/NewCoverageChecker.java
@@ -26,6 +26,7 @@ import com.naver.nid.cover.parser.coverage.model.LineCoverageReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -50,7 +51,7 @@ public class NewCoverageChecker {
 	 * @return 전체 커버리지, 파일 별 커버리지
 	 */
 	public NewCoverageCheckReport check(List<FileCoverageReport> coverage, List<Diff> diff, int threshold, int fileThreshold) {
-		Map<String, List<Line>> diffMap = diff.stream()
+		Map<Path, List<Line>> diffMap = diff.stream()
 				.filter(Objects::nonNull)
 				.peek(d -> logger.debug("diff file {}", d.getFileName()))
 				.filter(d -> !d.getFileName().startsWith("src/test"))
@@ -63,7 +64,7 @@ public class NewCoverageChecker {
 								.collect(Collectors.toList())
 						, (u1, u2) -> Stream.concat(u1.stream(), u2.stream()).collect(Collectors.toList())));
 
-		Map<String, List<LineCoverageReport>> coverageMap = coverage.stream()
+		Map<Path, List<LineCoverageReport>> coverageMap = coverage.stream()
 				.peek(r -> logger.debug("file coverage {}", r.getFileName()))
 				.collect(Collectors.toMap(FileCoverageReport::getFileName
 						, FileCoverageReport::getLineCoverageReportList
@@ -84,14 +85,14 @@ public class NewCoverageChecker {
 	 * @param newCodeLines   add line of code for each files
 	 * @return new line of code coverage result
 	 */
-	private NewCoverageCheckReport combine(Map<String, List<LineCoverageReport>> coverageReport, Map<String, List<Line>> newCodeLines) {
+	private NewCoverageCheckReport combine(Map<Path, List<LineCoverageReport>> coverageReport, Map<Path, List<Line>> newCodeLines) {
 		int totalAddLineCount = 0;
 		int coveredLineCount = 0;
 
-		Set<String> files = new HashSet<>(coverageReport.keySet());
+		Set<Path> files = new HashSet<>(coverageReport.keySet());
 
 		List<NewCoveredFile> coveredFileList = new ArrayList<>();
-		for (String file : files) {
+		for (Path file : files) {
 			// TODO 다른 모듈의 동일 패키지 동일 파일 이름일 경우에 대한 처리 필요
 
 			// 코드 커버리지의 끝 경로가 같은 경우에 대해 검색

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/checker/model/NewCoveredFile.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/checker/model/NewCoveredFile.java
@@ -18,6 +18,8 @@ package com.naver.nid.cover.checker.model;
 import lombok.Builder;
 import lombok.Data;
 
+import java.nio.file.Path;
+
 import static com.naver.nid.cover.checker.model.ResultIcon.CHECK_FILE_FAIL;
 import static com.naver.nid.cover.checker.model.ResultIcon.CHECK_FILE_PASS;
 
@@ -25,7 +27,7 @@ import static com.naver.nid.cover.checker.model.ResultIcon.CHECK_FILE_PASS;
 @Builder
 public class NewCoveredFile {
 
-	private String name;
+	private Path name;
 	private int addedLine;
 	private int addedCoverLine;
 	private int threshold;

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/parser/coverage/model/FileCoverageReport.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/parser/coverage/model/FileCoverageReport.java
@@ -19,6 +19,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.nio.file.Path;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -26,7 +27,7 @@ import java.util.stream.Collectors;
 @AllArgsConstructor
 @NoArgsConstructor
 public class FileCoverageReport {
-	private String fileName;
+	private Path fileName;
 	private String type;
 	private List<LineCoverageReport> lineCoverageReportList;
 

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/parser/diff/DiffMapper.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/parser/diff/DiffMapper.java
@@ -19,6 +19,8 @@ import com.naver.nid.cover.parser.diff.exception.ParseException;
 import com.naver.nid.cover.parser.diff.model.*;
 import lombok.extern.slf4j.Slf4j;
 
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -49,7 +51,7 @@ public class DiffMapper implements Function<RawDiff, Diff> {
 		Diff diff = new Diff();
 
 		// set file name
-		Optional<String> fileName = Optional.ofNullable(rawDiff.getFileName()).map(this::removeNewFilePrefix);
+		Optional<Path> fileName = Optional.ofNullable(rawDiff.getFileName()).map(this::removeNewFilePrefix);
 		log.info("parse diff / {}", fileName);
 
 		if (!fileName.isPresent()) {
@@ -98,11 +100,11 @@ public class DiffMapper implements Function<RawDiff, Diff> {
 		return line.contains("\\ No newline at end of file");
 	}
 
-	private String removeNewFilePrefix(String path) {
+	private Path removeNewFilePrefix(String path) {
 		if (path.startsWith("b/")) {
 			path = path.replaceFirst("b/", "");
 		}
-		return path;
+		return Paths.get(path);
 	}
 
 	private Optional<List<DiffSection>> getDiffSectionListFromRawDiff(RawDiff rawDiff) {

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/parser/diff/DiffMapper.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/parser/diff/DiffMapper.java
@@ -17,6 +17,7 @@ package com.naver.nid.cover.parser.diff;
 
 import com.naver.nid.cover.parser.diff.exception.ParseException;
 import com.naver.nid.cover.parser.diff.model.*;
+import com.naver.nid.cover.util.PathUtils;
 import lombok.extern.slf4j.Slf4j;
 
 import java.nio.file.Path;
@@ -104,7 +105,7 @@ public class DiffMapper implements Function<RawDiff, Diff> {
 		if (path.startsWith("b/")) {
 			path = path.replaceFirst("b/", "");
 		}
-		return Paths.get(path);
+		return Paths.get(PathUtils.generalizeSeparator(path));
 	}
 
 	private Optional<List<DiffSection>> getDiffSectionListFromRawDiff(RawDiff rawDiff) {

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/parser/diff/model/Diff.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/parser/diff/model/Diff.java
@@ -17,6 +17,7 @@ package com.naver.nid.cover.parser.diff.model;
 
 import lombok.*;
 
+import java.nio.file.Path;
 import java.util.List;
 
 /**
@@ -29,6 +30,6 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 public class Diff {
-	private String fileName;
+	private Path fileName;
 	private List<DiffSection> diffSectionList;
 }

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/util/PathUtils.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/util/PathUtils.java
@@ -1,0 +1,30 @@
+package com.naver.nid.cover.util;
+
+import java.io.File;
+
+public class PathUtils {
+    private PathUtils() {
+    }
+
+    /**
+     * <p>generalize file path</p>
+     *
+     * <h3>in Windows</h3>
+     * <ul>
+     * <li>- test/test.java -> test\test.java</li>
+     * <li>- test\test.java -> test\test.java</li>
+     * </ul>
+     *
+     * <h3>in Posix</h3>
+     *  <ul>
+     *  <li>- test/test.java -> test/test.java</li>
+     *  <li>- test\test.java -> test/test.java</li>
+     *  </ul>
+     * @param path path from reports(github, jacoco, cobertura...)
+     * @return generalized path that replaced separator that OS used
+     */
+    public static String generalizeSeparator(String path) {
+        if (path == null || path.isEmpty()) return path;
+        return path.replaceAll("[\\\\/]", File.separator);
+    }
+}

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/util/PathUtils.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/util/PathUtils.java
@@ -1,6 +1,22 @@
+/*
+	Copyright 2021 NAVER Corp.
+
+	Licensed under the Apache License, Version 2.0 (the "License");
+	you may not use this file except in compliance with the License.
+	You may obtain a copy of the License at
+
+		http://www.apache.org/licenses/LICENSE-2.0
+
+	Unless required by applicable law or agreed to in writing, software
+	distributed under the License is distributed on an "AS IS" BASIS,
+	WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+	See the License for the specific language governing permissions and
+	limitations under the License.
+ */
 package com.naver.nid.cover.util;
 
 import java.io.File;
+import java.util.regex.Matcher;
 
 public class PathUtils {
     private PathUtils() {
@@ -25,6 +41,6 @@ public class PathUtils {
      */
     public static String generalizeSeparator(String path) {
         if (path == null || path.isEmpty()) return path;
-        return path.replaceAll("[\\\\/]", File.separator);
+        return path.replaceAll("[\\\\/]", Matcher.quoteReplacement(File.separator));
     }
 }

--- a/cover-checker-core/src/test/java/com/naver/nid/cover/CoverCheckerTest.java
+++ b/cover-checker-core/src/test/java/com/naver/nid/cover/CoverCheckerTest.java
@@ -21,6 +21,7 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -54,8 +55,8 @@ class CoverCheckerTest {
 				, Line.builder().lineNumber(2).type(ModifyType.ADD).build());
 
 		List<DiffSection> diffSectionList = Collections.singletonList(DiffSection.builder().lineList(lines).build());
-		Stream<Diff> diffStream = Stream.of(Diff.builder().fileName("test.java").diffSectionList(diffSectionList).build(),
-			Diff.builder().fileName("test2.java").diffSectionList(diffSectionList).build());
+		Stream<Diff> diffStream = Stream.of(Diff.builder().fileName(Paths.get("test.java")).diffSectionList(diffSectionList).build(),
+			Diff.builder().fileName(Paths.get("test2.java")).diffSectionList(diffSectionList).build());
 
 
 		LineCoverageReport lineCoverageReport = new LineCoverageReport();
@@ -68,11 +69,11 @@ class CoverCheckerTest {
 
 		FileCoverageReport fileCoverageReport = new FileCoverageReport();
 		fileCoverageReport.setType("java");
-		fileCoverageReport.setFileName("test.java");
+		fileCoverageReport.setFileName(Paths.get("test.java"));
 		fileCoverageReport.setLineCoverageReportList(Arrays.asList(lineCoverageReport, lineCoverageReport2));
 		FileCoverageReport fileCoverageReport2 = new FileCoverageReport();
 		fileCoverageReport.setType("java");
-		fileCoverageReport.setFileName("test2.java");
+		fileCoverageReport.setFileName(Paths.get("test2.java"));
 		fileCoverageReport.setLineCoverageReportList(Arrays.asList(lineCoverageReport, lineCoverageReport2));
 		List<FileCoverageReport> coverageModule1 = Collections.singletonList(fileCoverageReport);
 		List<FileCoverageReport> coverageModule2 = Collections.singletonList(fileCoverageReport2);
@@ -83,7 +84,7 @@ class CoverCheckerTest {
 				.coveredNewLine(1)
 				.coveredFilesInfo(
 						Collections.singletonList(NewCoveredFile.builder()
-								.name("test.java")
+								.name(Paths.get("test.java"))
 								.addedLine(2)
 								.addedCoverLine(1)
 								.build()))

--- a/cover-checker-core/src/test/java/com/naver/nid/cover/checker/NewCoverageCheckerTest.java
+++ b/cover-checker-core/src/test/java/com/naver/nid/cover/checker/NewCoverageCheckerTest.java
@@ -159,4 +159,46 @@ class NewCoverageCheckerTest {
         NewCoverageCheckReport check = checker.check(coverage, diffList, 60, 0);
         assertEquals(newCoverageCheckReport, check);
     }
+
+    @Test
+    public void coverCheckTestForWindowPath() {
+        NewCoverageChecker checker = new NewCoverageChecker();
+
+        List<Line> lines = Arrays.asList(
+                Line.builder().lineNumber(1).type(ModifyType.ADD).build()
+                , Line.builder().lineNumber(2).type(ModifyType.ADD).build());
+
+        List<DiffSection> diffSectionList = Collections.singletonList(DiffSection.builder().lineList(lines).build());
+        List<Diff> diffList = Collections.singletonList(Diff.builder().fileName(Paths.get("src\\main\\com\\naver\\nid\\test.kt")).diffSectionList(diffSectionList).build());
+
+
+        LineCoverageReport lineCoverageReport = new LineCoverageReport();
+        lineCoverageReport.setStatus(CoverageStatus.COVERED);
+        lineCoverageReport.setLineNum(1);
+
+        LineCoverageReport lineCoverageReport2 = new LineCoverageReport();
+        lineCoverageReport2.setStatus(CoverageStatus.UNCOVERED);
+        lineCoverageReport2.setLineNum(2);
+
+        FileCoverageReport fileCoverageReport = new FileCoverageReport();
+        fileCoverageReport.setType("kt");
+        fileCoverageReport.setFileName(Paths.get("src\\main\\com\\naver\\nid\\test.kt"));
+        fileCoverageReport.setLineCoverageReportList(Arrays.asList(lineCoverageReport, lineCoverageReport2));
+        List<FileCoverageReport> coverage = Collections.singletonList(fileCoverageReport);
+
+        NewCoverageCheckReport newCoverageCheckReport = NewCoverageCheckReport.builder()
+                .threshold(60)
+                .totalNewLine(2)
+                .coveredNewLine(1)
+                .coveredFilesInfo(
+                        Collections.singletonList(NewCoveredFile.builder()
+                                .name(Paths.get("src\\main\\com\\naver\\nid\\test.kt"))
+                                .addedLine(2)
+                                .addedCoverLine(1)
+                                .build()))
+                .build();
+
+        NewCoverageCheckReport check = checker.check(coverage, diffList, 60, 0);
+        assertEquals(newCoverageCheckReport, check);
+    }
 }

--- a/cover-checker-core/src/test/java/com/naver/nid/cover/checker/NewCoverageCheckerTest.java
+++ b/cover-checker-core/src/test/java/com/naver/nid/cover/checker/NewCoverageCheckerTest.java
@@ -11,6 +11,7 @@ import com.naver.nid.cover.parser.diff.model.Line;
 import com.naver.nid.cover.parser.diff.model.ModifyType;
 import org.junit.jupiter.api.Test;
 
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +29,7 @@ class NewCoverageCheckerTest {
                 , Line.builder().lineNumber(2).type(ModifyType.ADD).build());
 
         List<DiffSection> diffSectionList = Collections.singletonList(DiffSection.builder().lineList(lines).build());
-        List<Diff> diffList = Collections.singletonList(Diff.builder().fileName("test.java").diffSectionList(diffSectionList).build());
+        List<Diff> diffList = Collections.singletonList(Diff.builder().fileName(Paths.get("test.java")).diffSectionList(diffSectionList).build());
 
 
         LineCoverageReport lineCoverageReport = new LineCoverageReport();
@@ -41,7 +42,7 @@ class NewCoverageCheckerTest {
 
         FileCoverageReport fileCoverageReport = new FileCoverageReport();
         fileCoverageReport.setType("java");
-        fileCoverageReport.setFileName("test.java");
+        fileCoverageReport.setFileName(Paths.get("test.java"));
         fileCoverageReport.setLineCoverageReportList(Arrays.asList(lineCoverageReport, lineCoverageReport2));
         List<FileCoverageReport> coverage = Collections.singletonList(fileCoverageReport);
 
@@ -51,7 +52,7 @@ class NewCoverageCheckerTest {
                 .coveredNewLine(1)
                 .coveredFilesInfo(
                         Collections.singletonList(NewCoveredFile.builder()
-                                .name("test.java")
+                                .name(Paths.get("test.java"))
                                 .addedLine(2)
                                 .addedCoverLine(1)
                                 .build()))
@@ -71,7 +72,7 @@ class NewCoverageCheckerTest {
                 , Line.builder().lineNumber(2).type(ModifyType.ADD).build());
 
         List<DiffSection> diffSectionList = Collections.singletonList(DiffSection.builder().lineList(lines).build());
-        List<Diff> diffList = Collections.singletonList(Diff.builder().fileName("test.kt").diffSectionList(diffSectionList).build());
+        List<Diff> diffList = Collections.singletonList(Diff.builder().fileName(Paths.get("test.kt")).diffSectionList(diffSectionList).build());
 
 
         LineCoverageReport lineCoverageReport = new LineCoverageReport();
@@ -84,7 +85,7 @@ class NewCoverageCheckerTest {
 
         FileCoverageReport fileCoverageReport = new FileCoverageReport();
         fileCoverageReport.setType("java");
-        fileCoverageReport.setFileName("test.kt");
+        fileCoverageReport.setFileName(Paths.get("test.kt"));
         fileCoverageReport.setLineCoverageReportList(Arrays.asList(lineCoverageReport, lineCoverageReport2));
         List<FileCoverageReport> coverage = Collections.singletonList(fileCoverageReport);
 
@@ -94,7 +95,7 @@ class NewCoverageCheckerTest {
                 .coveredNewLine(1)
                 .coveredFilesInfo(
                         Collections.singletonList(NewCoveredFile.builder()
-                                .name("test.kt")
+                                .name(Paths.get("test.kt"))
                                 .addedLine(2)
                                 .addedCoverLine(1)
                                 .build()))
@@ -114,8 +115,8 @@ class NewCoverageCheckerTest {
 
         List<DiffSection> diffSectionList = Collections.singletonList(DiffSection.builder().lineList(lines).build());
         List<Diff> diffList = Arrays.asList(
-                Diff.builder().fileName("Module1/src/main/kotlin/test.kt").diffSectionList(diffSectionList).build(),
-                Diff.builder().fileName("Module2/src/main/kotlin/test.kt").diffSectionList(diffSectionList).build());
+                Diff.builder().fileName(Paths.get("Module1/src/main/kotlin/test.kt")).diffSectionList(diffSectionList).build(),
+                Diff.builder().fileName(Paths.get("Module2/src/main/kotlin/test.kt")).diffSectionList(diffSectionList).build());
 
 
         LineCoverageReport lineCoverageReport = new LineCoverageReport();
@@ -128,12 +129,12 @@ class NewCoverageCheckerTest {
 
         FileCoverageReport fileCoverageReport = new FileCoverageReport();
         fileCoverageReport.setType("kt");
-        fileCoverageReport.setFileName("Module1/src/main/kotlin/test.kt");
+        fileCoverageReport.setFileName(Paths.get("Module1/src/main/kotlin/test.kt"));
         fileCoverageReport.setLineCoverageReportList(Arrays.asList(lineCoverageReport, lineCoverageReport2));
 
         FileCoverageReport fileCoverageReport2 = new FileCoverageReport();
         fileCoverageReport2.setType("kt");
-        fileCoverageReport2.setFileName("Module2/src/main/kotlin/test.kt");
+        fileCoverageReport2.setFileName(Paths.get("Module2/src/main/kotlin/test.kt"));
         fileCoverageReport2.setLineCoverageReportList(Arrays.asList(lineCoverageReport, lineCoverageReport2));
 
         List<FileCoverageReport> coverage = Arrays.asList(fileCoverageReport, fileCoverageReport2);
@@ -144,12 +145,12 @@ class NewCoverageCheckerTest {
                 .coveredNewLine(2)
                 .coveredFilesInfo(
                         Arrays.asList(NewCoveredFile.builder()
-                                        .name("Module2/src/main/kotlin/test.kt")
+                                        .name(Paths.get("Module2/src/main/kotlin/test.kt"))
                                         .addedLine(2)
                                         .addedCoverLine(1)
                                         .build(),
                                 NewCoveredFile.builder()
-                                        .name("Module1/src/main/kotlin/test.kt")
+                                        .name(Paths.get("Module1/src/main/kotlin/test.kt"))
                                         .addedLine(2)
                                         .addedCoverLine(1)
                                         .build()))

--- a/cover-checker-core/src/test/java/com/naver/nid/cover/parser/diff/FileDiffParseTest.java
+++ b/cover-checker-core/src/test/java/com/naver/nid/cover/parser/diff/FileDiffParseTest.java
@@ -11,6 +11,7 @@ import org.slf4j.LoggerFactory;
 import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -45,7 +46,7 @@ class FileDiffParseTest {
 
 		assertEquals(1, collect.size());
 		Diff diff = collect.get(0);
-		assertEquals("src/main/java/com/naver/nid/push/token/service/TokenService.java", diff.getFileName());
+		assertEquals(Paths.get("src/main/java/com/naver/nid/push/token/service/TokenService.java"), diff.getFileName());
 		assertEquals(1, diff.getDiffSectionList().size());
 
 		DiffSection diffSection = diff.getDiffSectionList().get(0);
@@ -65,7 +66,7 @@ class FileDiffParseTest {
 
 		int testLineNum = parsedList.stream()
 //				.peek(diff -> logger.debug("diff file name {}", diff.getFileName()))
-				.filter(d -> d.getFileName().contains("TestService.java"))
+				.filter(d -> d.getFileName().endsWith("TestService.java"))
 				.flatMap(d -> d.getDiffSectionList().stream())
 //				.peek(diffSection -> logger.debug("find diff {}", diffSection))
 				.flatMap(diffSection -> diffSection.getLineList().stream())

--- a/cover-checker-core/src/test/java/com/naver/nid/cover/util/PathUtilsTest.java
+++ b/cover-checker-core/src/test/java/com/naver/nid/cover/util/PathUtilsTest.java
@@ -1,0 +1,27 @@
+package com.naver.nid.cover.util;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.*;
+
+import java.io.File;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+class PathUtilsTest {
+
+    @ParameterizedTest
+    @MethodSource("testCase")
+    void generalizeSeparator(String path, String expect) {
+        assertEquals(expect, PathUtils.generalizeSeparator(path));
+    }
+
+    static Stream<Arguments> testCase() {
+        return Stream.of(
+                arguments(null, null),
+                arguments("", ""),
+                arguments("test/test.java","test" + File.separator + "test.java"),
+                arguments("test\\test.java","test" + File.separator + "test.java"));
+    }
+}

--- a/cover-checker-core/src/test/resources/logback-test.xml
+++ b/cover-checker-core/src/test/resources/logback-test.xml
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <configuration>
-    <include resource="pattern.xml" />
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level \(%file:%line\) %msg%n</pattern>
+        </encoder>
+    </appender>
 
     <root level="DEBUG">
         <appender-ref ref="console"/>

--- a/cover-checker-github/pom.xml
+++ b/cover-checker-github/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>coverchecker</artifactId>
         <groupId>com.naver.nid</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cover-checker-github/src/test/java/com/naver/nid/cover/github/reporter/GithubPullRequestReporterTest.java
+++ b/cover-checker-github/src/test/java/com/naver/nid/cover/github/reporter/GithubPullRequestReporterTest.java
@@ -7,7 +7,6 @@ import com.naver.nid.cover.github.manager.GithubCommentManager;
 import com.naver.nid.cover.github.manager.GithubPullRequestManager;
 import com.naver.nid.cover.github.manager.GithubStatusManager;
 import com.naver.nid.cover.github.manager.model.CommitStatusCreate;
-import org.eclipse.egit.github.core.User;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.Arrays;
 
 import static org.mockito.Mockito.*;
@@ -92,8 +92,8 @@ class GithubPullRequestReporterTest {
 				.totalNewLine(3)
 				.coveredNewLine(2)
 				.threshold(50)
-				.coveredFilesInfo(Arrays.asList(NewCoveredFile.builder().name("test.java").addedLine(100).addedCoverLine(50).build(),
-						NewCoveredFile.builder().name("test2.java").addedLine(100).addedCoverLine(50).build()))
+				.coveredFilesInfo(Arrays.asList(NewCoveredFile.builder().name(Paths.get("test.java")).addedLine(100).addedCoverLine(50).build(),
+						NewCoveredFile.builder().name(Paths.get("test2.java")).addedLine(100).addedCoverLine(50).build()))
 				.build();
 
 		reporter.report(result);
@@ -119,8 +119,8 @@ class GithubPullRequestReporterTest {
 				.totalNewLine(3)
 				.coveredNewLine(2)
 				.threshold(50)
-				.coveredFilesInfo(Arrays.asList(NewCoveredFile.builder().name("test.java").addedLine(100).addedCoverLine(50).build(),
-						NewCoveredFile.builder().name("test2.java").addedLine(100).addedCoverLine(30).build()))
+				.coveredFilesInfo(Arrays.asList(NewCoveredFile.builder().name(Paths.get("test.java")).addedLine(100).addedCoverLine(50).build(),
+						NewCoveredFile.builder().name(Paths.get("test2.java")).addedLine(100).addedCoverLine(30).build()))
 				.build();
 		result.setFileThreshold(50);
 

--- a/cover-checker-jacoco/pom.xml
+++ b/cover-checker-jacoco/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>coverchecker</artifactId>
         <groupId>com.naver.nid</groupId>
-        <version>1.4.1</version>
+        <version>1.4.2</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/cover-checker-jacoco/src/main/java/com/naver/nid/cover/jacoco/JacocoHtmlReportParser.java
+++ b/cover-checker-jacoco/src/main/java/com/naver/nid/cover/jacoco/JacocoHtmlReportParser.java
@@ -90,8 +90,8 @@ public class JacocoHtmlReportParser implements CoverageReportParser {
 			String filePath = file.getCanonicalPath();
 			logger.debug("parse {}", filePath);
 			String[] split = filePath.split("[/\\\\]");
-			String sourcePath = split[split.length - 2].replace(".", "/") + "/" + split[split.length - 1].replace(".html", "");
-			fileReport.setFileName(sourcePath);
+			String sourcePath = split[split.length - 2].replace(".", File.separator) + File.separator + split[split.length - 1].replace(".html", "");
+			fileReport.setFileName(Paths.get(sourcePath));
 			fileReport.setType(file.getName().split("\\.")[1]);
 
 			List<LineCoverageReport> lineCoverageReports = doc.select(".linenums span").stream()

--- a/cover-checker-jacoco/src/main/java/com/naver/nid/cover/jacoco/JacocoXmlCoverageReportHandler.java
+++ b/cover-checker-jacoco/src/main/java/com/naver/nid/cover/jacoco/JacocoXmlCoverageReportHandler.java
@@ -23,6 +23,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.xml.sax.Attributes;
 
 import java.math.BigInteger;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -31,8 +33,9 @@ import java.util.Map;
 @Slf4j
 public class JacocoXmlCoverageReportHandler extends CoverageReportXmlHandler {
 
+	private final Map<Path, FileCoverageReport> reportMap = new HashMap<>();
+
 	private String pkgPath;
-	private Map<String, FileCoverageReport> reportMap = new HashMap<>();
 	private FileCoverageReport currentFile;
 	private List<LineCoverageReport> lineReports;
 
@@ -47,7 +50,7 @@ public class JacocoXmlCoverageReportHandler extends CoverageReportXmlHandler {
 			case "sourcefile":
 				currentFile = new FileCoverageReport();
 				String name = attributes.getValue("name");
-				currentFile.setFileName(pkgPath + "/" + name);
+				currentFile.setFileName(Paths.get(pkgPath, name));
 				currentFile.setType(name.substring(name.lastIndexOf('.') + 1));
 				log.debug("found new file {}", currentFile.getFileName());
 				lineReports = new ArrayList<>();

--- a/cover-checker-jacoco/src/main/java/com/naver/nid/cover/jacoco/JacocoXmlCoverageReportHandler.java
+++ b/cover-checker-jacoco/src/main/java/com/naver/nid/cover/jacoco/JacocoXmlCoverageReportHandler.java
@@ -19,6 +19,7 @@ import com.naver.nid.cover.parser.coverage.CoverageReportXmlHandler;
 import com.naver.nid.cover.parser.coverage.model.CoverageStatus;
 import com.naver.nid.cover.parser.coverage.model.FileCoverageReport;
 import com.naver.nid.cover.parser.coverage.model.LineCoverageReport;
+import com.naver.nid.cover.util.PathUtils;
 import lombok.extern.slf4j.Slf4j;
 import org.xml.sax.Attributes;
 
@@ -44,7 +45,7 @@ public class JacocoXmlCoverageReportHandler extends CoverageReportXmlHandler {
 		if (localName.equals("")) localName = qName;
 		switch (localName) {
 			case "package":
-				pkgPath = attributes.getValue("name");
+				pkgPath = PathUtils.generalizeSeparator(attributes.getValue("name"));
 				log.debug("found new package {}", pkgPath);
 				break;
 			case "sourcefile":

--- a/cover-checker-jacoco/src/test/java/com/naver/nid/cover/jacoco/JacocoHtmlReportParserTest.java
+++ b/cover-checker-jacoco/src/test/java/com/naver/nid/cover/jacoco/JacocoHtmlReportParserTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.net.URL;
+import java.nio.file.Paths;
 import java.util.List;
 
 @Slf4j
@@ -27,7 +28,7 @@ class JacocoHtmlReportParserTest {
 		log.debug("{}", parse);
 
 		FileCoverageReport fileCoverageReport = parse.get(0);
-		Assertions.assertEquals("com/naver/nid/cover/github/GithubCommentManager.java", fileCoverageReport.getFileName());
+		Assertions.assertEquals(Paths.get("com/naver/nid/cover/github/GithubCommentManager.java"), fileCoverageReport.getFileName());
 		Assertions.assertEquals("java", fileCoverageReport.getType());
 		Assertions.assertEquals(CoverageStatus.COVERED, fileCoverageReport.getLineCoverageReportList().stream().filter(l -> l.getLineNum() == 21).findFirst().orElseThrow(AssertionError::new).getStatus());
 	}
@@ -46,7 +47,7 @@ class JacocoHtmlReportParserTest {
 		log.debug("{}", reports);
 
 		FileCoverageReport fileCoverageReport = reports.get(0);
-		Assertions.assertEquals("com/naver/nid/cover/github/GithubCommentManager.java", fileCoverageReport.getFileName());
+		Assertions.assertEquals(Paths.get("com/naver/nid/cover/github/GithubCommentManager.java"), fileCoverageReport.getFileName());
 		Assertions.assertEquals("java", fileCoverageReport.getType());
 		Assertions.assertEquals(CoverageStatus.COVERED, fileCoverageReport.getLineCoverageReportList().stream().filter(l -> l.getLineNum() == 21).findFirst().orElseThrow(AssertionError::new).getStatus());
 	}

--- a/cover-checker-jacoco/src/test/java/com/naver/nid/cover/jacoco/JacocoXmlReportParserTest.java
+++ b/cover-checker-jacoco/src/test/java/com/naver/nid/cover/jacoco/JacocoXmlReportParserTest.java
@@ -22,7 +22,7 @@ public class JacocoXmlReportParserTest {
 		List<FileCoverageReport> parsed = parser.parse(getClass().getClassLoader().getResource("reports/jacoco.xml"));
 		assertEquals(38, parsed.size());
 		assertSame(CoverageStatus.COVERED, parsed.stream()
-				.filter(r -> r.getFileName().contains("Parameter"))
+				.filter(r -> r.getFileName().endsWith("Parameter.java"))
 				.findFirst().flatMap(r -> r.getLineCoverageReportList().stream()
 						.filter(lr -> lr.getLineNum() == 8).findFirst()).orElseThrow(AssertionError::new).getStatus());
 	}

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.naver.nid</groupId>
     <artifactId>coverchecker</artifactId>
-    <version>1.4.1</version>
+    <version>1.4.2</version>
 
     <modules>
         <module>cover-checker-github</module>
@@ -43,14 +43,14 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <version>RELEASE</version>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
-            <version>RELEASE</version>
+            <version>5.7.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,18 @@
 
     <packaging>pom</packaging>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.7.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- https://mvnrepository.com/artifact/ch.qos.logback/logback-classic -->
         <dependency>
@@ -42,15 +54,7 @@
 
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-api</artifactId>
-            <version>5.7.0</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
-            <version>5.7.0</version>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
resolved #30 

- Use `Path` instead of `String` for filename field type
- Generalize path by `File.separate` before create `Path` instance

additional...
- fix deprecated maven option
