### PR TITLE
fix concurrency bug and improve argument parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ then maven would make jar `cover-checker-console/build/libs/cover-checker-${vers
 
 # Create access token
 
-Create a [access token](https://github.com/settings/tokens/new?scopes=repo&description=cover-checker)
+Create an [access token](https://github.com/settings/tokens/new?scopes=repo&description=cover-checker)
 
 # Execute with parameter
 
@@ -56,7 +56,18 @@ java -jar cover-checker-console/build/libs/cover-checker-${version}-all.jar \
     --threshold ${coverageThreshold} \
     --github-url ${githubHost} \
     --pr ${pullrequestNo} \
-    -type (jacoco | cobertura)
+    [-type (jacoco | cobertura)]
+```
+
+Note that both the `--cover` and `-type` parameters can be specified multiple times and are associated positionally.
+
+For example, if you have two coverage reports in different formats, you can specify them like this:
+
+```sh
+java -jar cover-checker-console/build/libs/cover-checker-${version}-all.jar \
+    -type jacoco --cover jacoco.xml \
+    -type cobertura --cover cobertura.xml \
+    ... # other parameters
 ```
 
 ### Parameter

--- a/README_ko.md
+++ b/README_ko.md
@@ -54,7 +54,7 @@ java -jar cover-checker-console/target/cover-checker-console-${version}-jar-with
     --threshold ${coverageThreshold} \
     --github-url ${githubHost} \
     --pr ${pullrequestNo} \
-    -type (jacoco | cobertura)
+    [-type (jacoco | cobertura)]
 ```
 
 ### 파라메터 설명

--- a/cover-checker-console/src/main/java/com/naver/nid/cover/Launcher.java
+++ b/cover-checker-console/src/main/java/com/naver/nid/cover/Launcher.java
@@ -6,15 +6,21 @@ import com.naver.nid.cover.util.ParameterParser;
 
 public class Launcher {
 
-    public static void main(String[] args) {
+    public static int run(String[] args) {
         Parameter param = new ParameterParser().getParam(args);
-        if (param == null) return;
-
+        if (param == null) {
+            return 1;
+        }
         ObjectFactory objectManager = new ObjectFactory(param);
         new CoverChecker(objectManager.getCoverageReportParser(),
                 objectManager.getDiffReader(),
                 objectManager.getNewCoverageParser(),
                 objectManager.getReporter()).check(param);
+        return 0;
+    }
+
+    public static void main(String[] args) {
+        System.exit(run(args));
     }
 
 }

--- a/cover-checker-console/src/main/java/com/naver/nid/cover/util/ObjectFactory.java
+++ b/cover-checker-console/src/main/java/com/naver/nid/cover/util/ObjectFactory.java
@@ -28,6 +28,10 @@ import com.naver.nid.cover.reporter.Reporter;
 import com.naver.nid.cover.reporter.ConsoleReporter;
 import com.naver.nid.cover.github.reporter.GithubPullRequestReporter;
 
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
 /**
  * {@link Parameter}에 따라 내부 객체를 생성하는 Factory 객체
  */
@@ -47,12 +51,19 @@ public class ObjectFactory {
         }
     }
 
-    public CoverageReportParser getCoverageReportParser() {
-        if ("cobertura".equals(param.getCoverageType())) {
-            return new XmlCoverageReportParser(new CoberturaCoverageReportHandler());
-        } else {
-            return new JacocoReportParser();
-        }
+    public List<CoverageReportParser> getCoverageReportParser() {
+        return IntStream.range(0, param.getCoveragePath().size())
+                .mapToObj(index -> {
+                    final CoverageType coverageType = param.getCoverageType().get(index);
+                    switch (coverageType) {
+                        case JACOCO:
+                            return new JacocoReportParser();
+                        case COBERTURA:
+                            return new XmlCoverageReportParser(new CoberturaCoverageReportHandler());
+                        default:
+                            throw new IllegalArgumentException("Unknown coverage type: " + coverageType);
+                    }
+                }).collect(Collectors.toList());
     }
 
     public NewCoverageChecker getNewCoverageParser() {

--- a/cover-checker-console/src/test/java/com/naver/nid/cover/LauncherTest.java
+++ b/cover-checker-console/src/test/java/com/naver/nid/cover/LauncherTest.java
@@ -7,11 +7,12 @@ import static org.junit.jupiter.api.Assertions.*;
 class LauncherTest {
 
     @Test
-    public void testMain() {
-        Launcher.main(new String[]{""});
+    public void testRun() {
+        int exitCode = Launcher.run(new String[]{""});
+        assertEquals(1, exitCode);
         // execution fail
         // because there is no parameters for execute cover-checker
-        assertThrows(NullPointerException.class, () -> Launcher.main("-c path -t 80 -dt file".split(" ")));
+        assertThrows(NullPointerException.class, () -> Launcher.run("-c path -t 80 -dt file".split(" ")));
     }
 
 }

--- a/cover-checker-console/src/test/java/com/naver/nid/cover/util/ObjectFactoryTest.java
+++ b/cover-checker-console/src/test/java/com/naver/nid/cover/util/ObjectFactoryTest.java
@@ -9,6 +9,7 @@ import com.naver.nid.cover.parser.diff.FileDiffReader;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -22,7 +23,10 @@ class ObjectFactoryTest {
 
     @Test
     void getCoberturaCoverageReportParser() throws NoSuchFieldException, IllegalAccessException {
-        CoverageReportParser cobertura = new ObjectFactory(Parameter.builder().coverageType("cobertura").build()).getCoverageReportParser();
+        CoverageReportParser cobertura = new ObjectFactory(Parameter.builder()
+                .coveragePath(Arrays.asList("dummy/path.xml"))
+                .coverageType(Arrays.asList(CoverageType.COBERTURA))
+                .build()).getCoverageReportParser().get(0);
         Field handler = XmlCoverageReportParser.class.getDeclaredField("handler");
         handler.setAccessible(true);
         assertEquals(CoberturaCoverageReportHandler.class, handler.get(cobertura).getClass());
@@ -30,7 +34,10 @@ class ObjectFactoryTest {
 
     @Test
     void getJacocoCoverageReportParser() {
-        CoverageReportParser jacoco = new ObjectFactory(Parameter.builder().build()).getCoverageReportParser();
+        CoverageReportParser jacoco = new ObjectFactory(Parameter.builder()
+                .coveragePath(Arrays.asList("dummy/path.xml"))
+                .coverageType(Arrays.asList(CoverageType.JACOCO))
+                .build()).getCoverageReportParser().get(0);
         assertEquals(JacocoReportParser.class, jacoco.getClass());
     }
 

--- a/cover-checker-console/src/test/java/com/naver/nid/cover/util/ParameterParserTest.java
+++ b/cover-checker-console/src/test/java/com/naver/nid/cover/util/ParameterParserTest.java
@@ -20,7 +20,52 @@ class ParameterParserTest {
 		assertEquals(IGitHubConstants.HOST_API, parameter.getGithubUrl());
 		assertEquals("repo", parameter.getRepo());
 		assertEquals(3, parameter.getPrNumber());
-		assertEquals("cobertura", parameter.getCoverageType());
+		assertEquals(Arrays.asList(CoverageType.COBERTURA, CoverageType.COBERTURA), parameter.getCoverageType());
+		assertEquals("com.naver.nid.cover.github", parameter.getDiffType());
+	}
+
+	@Test
+	public void testDifferentCoverageTypes() {
+		String param = "-type cobertura -c /path -type jacoco -c /path2 -d /diff_path -t 50 -g github_token -r repo -p 3 --diff-type com.naver.nid.cover.github";
+		Parameter parameter = new ParameterParser().getParam(param.split(" "));
+		assertEquals(Arrays.asList("/path", "/path2"), parameter.getCoveragePath());
+		assertEquals("/diff_path", parameter.getDiffPath());
+		assertEquals(50, parameter.getThreshold());
+		assertEquals("github_token", parameter.getGithubToken());
+		assertEquals(IGitHubConstants.HOST_API, parameter.getGithubUrl());
+		assertEquals("repo", parameter.getRepo());
+		assertEquals(3, parameter.getPrNumber());
+		assertEquals(Arrays.asList(CoverageType.COBERTURA, CoverageType.JACOCO), parameter.getCoverageType());
+		assertEquals("com.naver.nid.cover.github", parameter.getDiffType());
+	}
+
+	@Test
+	public void testCoverageTypeBroadcast() {
+		String param = "-type cobertura -c /path -c /path2 -c /path3 -d /diff_path -t 50 -g github_token -r repo -p 3 --diff-type com.naver.nid.cover.github";
+		Parameter parameter = new ParameterParser().getParam(param.split(" "));
+		assertEquals(Arrays.asList("/path", "/path2", "/path3"), parameter.getCoveragePath());
+		assertEquals("/diff_path", parameter.getDiffPath());
+		assertEquals(50, parameter.getThreshold());
+		assertEquals("github_token", parameter.getGithubToken());
+		assertEquals(IGitHubConstants.HOST_API, parameter.getGithubUrl());
+		assertEquals("repo", parameter.getRepo());
+		assertEquals(3, parameter.getPrNumber());
+		assertEquals(Arrays.asList(CoverageType.COBERTURA, CoverageType.COBERTURA, CoverageType.COBERTURA), parameter.getCoverageType());
+		assertEquals("com.naver.nid.cover.github", parameter.getDiffType());
+	}
+
+	@Test
+	public void testDefaultCoverageType() {
+		String param = "-c /path -d /diff_path -t 50 -g github_token -r repo -p 3 --diff-type com.naver.nid.cover.github";
+		Parameter parameter = new ParameterParser().getParam(param.split(" "));
+		assertEquals(Arrays.asList("/path"), parameter.getCoveragePath());
+		assertEquals("/diff_path", parameter.getDiffPath());
+		assertEquals(50, parameter.getThreshold());
+		assertEquals("github_token", parameter.getGithubToken());
+		assertEquals(IGitHubConstants.HOST_API, parameter.getGithubUrl());
+		assertEquals("repo", parameter.getRepo());
+		assertEquals(3, parameter.getPrNumber());
+		assertEquals(Arrays.asList(CoverageType.JACOCO), parameter.getCoverageType());
 		assertEquals("com.naver.nid.cover.github", parameter.getDiffType());
 	}
 

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/util/CoverageType.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/util/CoverageType.java
@@ -1,0 +1,33 @@
+package com.naver.nid.cover.util;
+
+public enum CoverageType {
+    JACOCO("jacoco"),
+    COBERTURA("cobertura");
+
+    final String name;
+
+    CoverageType(String name) {
+        this.name = name;
+    }
+
+    public static CoverageType parse(String coverageType) {
+        switch (coverageType.toLowerCase()) {
+            case "jacoco":
+                return JACOCO;
+            case "cobertura":
+                return COBERTURA;
+            default:
+                throw new IllegalArgumentException("Unknown coverage type: " + coverageType +
+                        ", available types: " + JACOCO + ", " + COBERTURA);
+        }
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+}

--- a/cover-checker-core/src/main/java/com/naver/nid/cover/util/Parameter.java
+++ b/cover-checker-core/src/main/java/com/naver/nid/cover/util/Parameter.java
@@ -34,5 +34,5 @@ public class Parameter {
 	private String repo;
 	private String diffType;
 	private int prNumber;
-	private String coverageType;
+	private List<CoverageType> coverageType;
 }

--- a/cover-checker-core/src/test/java/com/naver/nid/cover/CoverCheckerTest.java
+++ b/cover-checker-core/src/test/java/com/naver/nid/cover/CoverCheckerTest.java
@@ -14,6 +14,7 @@ import com.naver.nid.cover.parser.diff.model.Line;
 import com.naver.nid.cover.parser.diff.model.ModifyType;
 import com.naver.nid.cover.reporter.Reporter;
 import com.naver.nid.cover.reporter.ConsoleReporter;
+import com.naver.nid.cover.util.CoverageType;
 import com.naver.nid.cover.util.Parameter;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -48,7 +49,7 @@ class CoverCheckerTest {
 
 	@Test
 	public void testCheck() {
-		CoverChecker coverChecker = Mockito.spy(new CoverChecker(coverageReportParser, diffParser, checker, reporter));
+		CoverChecker coverChecker = Mockito.spy(new CoverChecker(Arrays.asList(coverageReportParser, coverageReportParser), diffParser, checker, reporter));
 
 		List<Line> lines = Arrays.asList(
 				Line.builder().lineNumber(1).type(ModifyType.ADD).build()
@@ -102,7 +103,7 @@ class CoverCheckerTest {
 				.coveragePath(null)
 				.diffPath("/path")
 				.coveragePath(Arrays.asList("test-module1", "test-module2"))
-				.coverageType("jacoco")
+				.coverageType(Arrays.asList(CoverageType.JACOCO, CoverageType.JACOCO))
 				.githubToken("token")
 				.githubUrl("enterprise.github.com")
 				.prNumber(1)


### PR DESCRIPTION
Closes https://github.com/naver/cover-checker/issues/37

Changes:
* Fix: Fixed concurrency issues by multiple parsers: One per thread.
* Feature: Allow specifying reports of different types on the command line.

The command line change has been implemented in a way to be backwards-compatible.